### PR TITLE
fix: 기획자-개발자 단계별 승인 및 회의 기록 시스템 추가 (#16)

### DIFF
--- a/app/models/db/meeting.py
+++ b/app/models/db/meeting.py
@@ -42,6 +42,18 @@ class MeetingLog(Base):
         comment="벡터 DB 참조 ID (Pinecone / Chroma 등)",
     )
 
+    # 스텝 조정 관련 필드
+    meeting_log_content = Column(
+        Text,
+        nullable=True,
+        comment="(선택 사항) 스텝 조정 시 발생한 회의 기록",
+    )
+    ai_translated_explanation = Column(
+        Text,
+        nullable=True,
+        comment="기술 소통을 돕기 위해 AI가 변환한 설명 텍스트",
+    )
+
     # 번역 세션 관련 필드
     is_translation_session = Column(
         Boolean,

--- a/app/models/db/pipeline.py
+++ b/app/models/db/pipeline.py
@@ -3,15 +3,18 @@ ORM 모델: Pipeline, PipelineStep
 
 DBML 대응:
   - pipelines: 프로젝트별 파이프라인 (project_id = Logical FK → Spring DB)
-  - pipeline_steps: 파이프라인 하위 스텝
+  - pipeline_steps: 파이프라인 하위 스텝 (기획자-개발자 승인 포함)
 """
+from datetime import datetime
+
 from sqlalchemy import (
-    Boolean,
     Column,
+    DateTime,
     ForeignKey,
     Integer,
     String,
     Text,
+    func,
 )
 from sqlalchemy.orm import relationship
 
@@ -30,7 +33,7 @@ class Pipeline(Base):
     )
     category = Column(String(100), nullable=True)
     version = Column(Integer, nullable=False, default=1)
-    is_active = Column(Boolean, nullable=False, default=True)
+    is_active = Column(String(10), nullable=False, default="Active", comment="Active | Inactive")
 
     # Relationships
     steps = relationship(
@@ -54,16 +57,54 @@ class PipelineStep(Base):
         nullable=False,
         index=True,
     )
-    title = Column(String(255), nullable=False)
-    description = Column(Text, nullable=True)
+    # 작업 상세 정보
+    step_task_description = Column(Text, nullable=False, comment="해당 스텝에서 수행할 구체적인 작업 상세 내용")
+    step_sequence_number = Column(Integer, nullable=False, comment="파이프라인 내 작업 배치 순서")
+
+    # GitHub 상태
+    step_github_status = Column(
+        String(50),
+        nullable=False,
+        default="Open",
+        comment="연동된 깃허브 이슈의 상태: Open | Closed",
+    )
+
+    # 승인 정보 (필수)
+    step_planner_confirm_yn = Column(
+        String(10),
+        nullable=False,
+        default="Pending",
+        comment="기획자의 해당 스텝 승인 여부: Pending | Approved",
+    )
+    step_developer_confirm_yn = Column(
+        String(10),
+        nullable=False,
+        default="Pending",
+        comment="개발자의 해당 스텝 승인 여부: Pending | Approved",
+    )
+    step_confirmation_date = Column(
+        DateTime,
+        nullable=True,
+        comment="양측 승인이 완료되어 스텝이 확정된 날짜",
+    )
+
+    # 추가 정보
     duration = Column(String(100), nullable=True, comment="예상 소요 시간 (예: '2-3일')")
     tech_stack = Column(String(200), nullable=True, comment="기술스택 (예: 'Spring Boot 3.x')")
-    is_completed = Column(Boolean, nullable=False, default=False)
     origin = Column(
         String(50),
         nullable=True,
         comment="생성 출처: ai_generated | user_created | meeting_derived",
     )
+
+    # Timestamps
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=func.now(),
+    )
+    updated_at = Column(DateTime, onupdate=datetime.utcnow)
 
     # Relationships
     pipeline = relationship("Pipeline", back_populates="steps")
@@ -75,4 +116,14 @@ class PipelineStep(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<PipelineStep(id={self.id}, title='{self.title}')>"
+        return f"<PipelineStep(id={self.id}, seq={self.step_sequence_number}, status={self.step_final_confirmed_status})>"
+
+    @property
+    def step_final_confirmed_status(self) -> str:
+        """계산 필드: 기획자와 개발자 모두 승인되었는지 확인"""
+        if (
+            self.step_planner_confirm_yn == "Approved"
+            and self.step_developer_confirm_yn == "Approved"
+        ):
+            return "Confirmed"
+        return "Pending"

--- a/app/schemas/meeting.py
+++ b/app/schemas/meeting.py
@@ -52,6 +52,12 @@ class MeetingLogCreate(BaseModel):
     """회의록 생성 요청"""
     project_id: int = Field(..., description="Logical FK → Spring DB: projects.id")
     content: str = Field(..., min_length=1, description="회의 원본 내용")
+    meeting_log_content: Optional[str] = Field(
+        None, description="(선택 사항) 스텝 조정 시 발생한 회의 기록"
+    )
+    ai_translated_explanation: Optional[str] = Field(
+        None, description="기술 소통을 돕기 위해 AI가 변환한 설명 텍스트"
+    )
     attendee_user_ids: Optional[List[int]] = Field(
         None, description="참석자 user_id 목록 (Logical FK → Spring DB)"
     )
@@ -62,6 +68,8 @@ class MeetingLogUpdate(BaseModel):
     content: Optional[str] = Field(None, min_length=1)
     summary: Optional[str] = None
     vector_id: Optional[str] = None
+    meeting_log_content: Optional[str] = None
+    ai_translated_explanation: Optional[str] = None
 
 
 class MeetingLogResponse(BaseModel):
@@ -73,6 +81,8 @@ class MeetingLogResponse(BaseModel):
     content: str
     summary: Optional[str] = None
     vector_id: Optional[str] = None
+    meeting_log_content: Optional[str] = None
+    ai_translated_explanation: Optional[str] = None
     created_at: datetime
     attendees: List[MeetingAttendeeResponse] = []
     step_relations: List[MeetingStepRelationResponse] = []

--- a/app/schemas/pipeline.py
+++ b/app/schemas/pipeline.py
@@ -2,9 +2,15 @@
 Pydantic v2 스키마: Pipeline & PipelineStep
 
 Request/Response DTO — ORM ↔ API 경계 분리
+
+요구사항:
+- Step_Planner_Confirm_YN, Step_Developer_Confirm_YN 필수
+- Step_Final_Confirmed_Status: 양측 모두 승인 시 'Confirmed'
+- Step_Confirmation_Date: 양측 승인 완료 날짜
 """
 from pydantic import BaseModel, Field, ConfigDict
 from typing import List, Optional
+from datetime import datetime
 
 
 # ──────────────────────────────────────────────
@@ -13,25 +19,32 @@ from typing import List, Optional
 
 class PipelineStepCreate(BaseModel):
     """파이프라인 스텝 생성 요청"""
-    title: str = Field(..., max_length=255, description="스텝 제목")
-    description: Optional[str] = Field(None, description="스텝 설명")
-    duration: Optional[str] = Field(None, max_length=100, description="예상 소요 시간")
+    step_task_description: str = Field(..., description="해당 스텝에서 수행할 구체적인 작업 상세 내용")
+    step_sequence_number: int = Field(..., ge=1, description="파이프라인 내 작업 배치 순서")
+    duration: Optional[str] = Field(None, max_length=100, description="예상 소요 시간 (예: '2-3일')")
     tech_stack: Optional[str] = Field(None, max_length=200, description="기술스택")
-    is_completed: bool = Field(False, description="완료 여부")
     origin: Optional[str] = Field(
-        None,
+        "user_created",
         max_length=50,
         description="생성 출처: ai_generated | user_created | meeting_derived",
     )
 
 
+class PipelineStepConfirmation(BaseModel):
+    """파이프라인 스텝 승인 요청"""
+    step_planner_confirm_yn: str = Field(..., description="기획자 승인: Pending | Approved")
+    step_developer_confirm_yn: str = Field(..., description="개발자 승인: Pending | Approved")
+
+
 class PipelineStepUpdate(BaseModel):
     """파이프라인 스텝 수정 요청"""
-    title: Optional[str] = Field(None, max_length=255)
-    description: Optional[str] = None
+    step_task_description: Optional[str] = None
+    step_sequence_number: Optional[int] = Field(None, ge=1)
+    step_github_status: Optional[str] = Field(None, description="Open | Closed")
+    step_planner_confirm_yn: Optional[str] = None
+    step_developer_confirm_yn: Optional[str] = None
     duration: Optional[str] = Field(None, max_length=100)
     tech_stack: Optional[str] = Field(None, max_length=200)
-    is_completed: Optional[bool] = None
     origin: Optional[str] = Field(None, max_length=50)
 
 
@@ -41,12 +54,18 @@ class PipelineStepResponse(BaseModel):
 
     id: int
     pipeline_id: int
-    title: str
-    description: Optional[str] = None
+    step_task_description: str
+    step_sequence_number: int
+    step_github_status: str
+    step_planner_confirm_yn: str
+    step_developer_confirm_yn: str
+    step_confirmation_date: Optional[datetime] = None
+    step_final_confirmed_status: str  # 계산 필드: Confirmed | Pending
     duration: Optional[str] = None
     tech_stack: Optional[str] = None
-    is_completed: bool
     origin: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 # ──────────────────────────────────────────────
@@ -58,7 +77,7 @@ class PipelineCreate(BaseModel):
     project_id: int = Field(..., description="Logical FK → Spring DB: projects.id")
     category: Optional[str] = Field(None, max_length=100, description="파이프라인 카테고리")
     version: int = Field(1, ge=1, description="버전")
-    is_active: bool = Field(True, description="활성 여부")
+    is_active: str = Field("Active", description="Active | Inactive")
     steps: Optional[List[PipelineStepCreate]] = Field(
         None, description="함께 생성할 스텝 목록 (선택)"
     )
@@ -68,7 +87,7 @@ class PipelineUpdate(BaseModel):
     """파이프라인 수정 요청"""
     category: Optional[str] = Field(None, max_length=100)
     version: Optional[int] = Field(None, ge=1)
-    is_active: Optional[bool] = None
+    is_active: Optional[str] = None
 
 
 class PipelineResponse(BaseModel):
@@ -79,7 +98,7 @@ class PipelineResponse(BaseModel):
     project_id: int
     category: Optional[str] = None
     version: int
-    is_active: bool
+    is_active: str
     steps: List[PipelineStepResponse] = []
 
 


### PR DESCRIPTION
[Python DB 스키마 수정]

Pipeline Step 필드 추가:
- step_task_description: 구체적인 작업 상세 내용
- step_sequence_number: 파이프라인 내 작업 배치 순서
- step_github_status: 연동 GitHub 이슈 상태 (Open/Closed)
- step_planner_confirm_yn: 기획자 승인 (Pending/Approved) - 필수
- step_developer_confirm_yn: 개발자 승인 (Pending/Approved) - 필수
- step_confirmation_date: 양측 승인 완료 날짜
- step_final_confirmed_status: 계산 필드 (둘 다 Approved 시 Confirmed)

Meeting Log 필드 추가:
- meeting_log_content: 스텝 조정 시 회의 기록 (선택사항)
- ai_translated_explanation: AI 변환 설명 텍스트

Pipeline is_active Boolean → String (Active/Inactive)

[스키마 업데이트]
- PipelineStepCreate: 새 필드 포함
- PipelineStepConfirmation: 승인 요청 DTO 추가
- PipelineStepResponse: 모든 새 필드 포함
- MeetingLogCreate/Update: meeting_log_content, ai_translated_explanation 추가